### PR TITLE
PIN-3/optimise-stalemate-detection

### DIFF
--- a/include/board.h
+++ b/include/board.h
@@ -903,6 +903,252 @@ class Board {
             }
         }
 
+        bool generateEvalMoves(bool side)
+        {
+            //only need one legal move to exit early.
+            moveBuffer.clear();
+            //generate all pseudo-legal moves.
+            updateOccupied();
+            updateAttacked(!side);
+
+            if (!(bool)(pieces[_nKing+(int)(side)] & attacked[(int)(!side)]))
+            {
+                //regular moves.
+                U32 pos; U64 x;
+
+                //castling.
+                if (current.canKingCastle[(int)(side)] &&
+                    !(bool)(KING_CASTLE_OCCUPIED[(int)(side)] & (occupied[0] | occupied[1])) &&
+                    !(bool)(KING_CASTLE_ATTACKED[(int)(side)] & attacked[(int)(!side)]))
+                {
+                    //kingside castle.
+                    pos = __builtin_ctzll(pieces[_nKing+(int)(side)]);
+                    appendMove(_nKing+(int)(side), pos, pos+2, false);
+                    return false;
+                }
+                if (current.canQueenCastle[(int)(side)] &&
+                    !(bool)(QUEEN_CASTLE_OCCUPIED[(int)(side)] & (occupied[0] | occupied[1])) &&
+                    !(bool)(QUEEN_CASTLE_ATTACKED[(int)(side)] & attacked[(int)(!side)]))
+                {
+                    //queenside castle.
+                    pos = __builtin_ctzll(pieces[_nKing+(int)(side)]);
+                    appendMove(_nKing+(int)(side), pos, pos-2, false);
+                    return false;
+                }
+
+                U64 pinned = getPinnedPieces(side);
+                U64 p = (occupied[0] | occupied[1]);
+
+                //knights.
+                U64 knights = pieces[_nKnights+(int)(side)] & ~pinned;
+                while (knights)
+                {
+                    pos = popLSB(knights);
+                    x = knightAttacks(1ull << pos) & ~occupied[(int)(side)];
+                    while (x)
+                    {
+                        appendMove(_nKnights+(int)(side), pos, popLSB(x), false);
+                        if (moveBuffer.size() > 0) {return false;}
+                    }
+                }
+
+                //bishops.
+                U64 bishops = pieces[_nBishops+(int)(side)];
+                while (bishops)
+                {
+                    pos = popLSB(bishops);
+                    x = magicBishopAttacks(p,pos) & ~occupied[(int)(side)];
+                    while (x)
+                    {
+                        appendMove(_nBishops+(int)(side), pos, popLSB(x), ((1ull << pos) & pinned)!=0);
+                        if (moveBuffer.size() > 0) {return false;}
+                    }
+                }
+
+                //pawns.
+                U64 pawns = pieces[_nPawns+(int)(side)];
+                U64 pawnPosBoard;
+                while (pawns)
+                {
+                    pos = popLSB(pawns);
+                    pawnPosBoard = 1ull << pos;
+                    //en passant square included.
+                    x = pawnAttacks(pawnPosBoard,side) & ~occupied[(int)(side)];
+
+                    if (current.enPassantSquare != -1) {x &= (occupied[(int)(!side)] | (1ull << current.enPassantSquare));}
+                    else {x &= occupied[(int)(!side)];}
+
+                    //move forward.
+                    if (side==0)
+                    {
+                        x |= (pawnPosBoard << 8) & (~p);
+                        x |= ((((pawnPosBoard & FILE_2) << 8) & (~p)) << 8) & (~p);
+                    }
+                    else
+                    {
+                        x |= (pawnPosBoard >> 8 & (~p));
+                        x |= ((((pawnPosBoard & FILE_7) >> 8) & (~p)) >> 8) & (~p);
+                    }
+
+                    while (x)
+                    {
+                        appendMove(_nPawns+(int)(side), pos,popLSB(x), (pawnPosBoard & pinned)!=0);
+                        if (moveBuffer.size() > 0) {return false;}
+                    }
+                }
+
+                //rook.
+                U64 rooks = pieces[_nRooks+(int)(side)];
+                while (rooks)
+                {
+                    pos = popLSB(rooks);
+                    x = magicRookAttacks(p,pos) & ~occupied[(int)(side)];
+                    while (x)
+                    {
+                        appendMove(_nRooks+(int)(side), pos, popLSB(x), ((1ull << pos) & pinned)!=0);
+                        if (moveBuffer.size() > 0) {return false;}
+                    }
+                }
+
+                //queen.
+                U64 queens = pieces[_nQueens+(int)(side)];
+                while (queens)
+                {
+                    pos = popLSB(queens);
+                    x = magicQueenAttacks(p,pos) & ~occupied[(int)(side)];
+                    while (x)
+                    {
+                        appendMove(_nQueens+(int)(side), pos, popLSB(x), ((1ull << pos) & pinned)!=0);
+                        if (moveBuffer.size() > 0) {return false;}
+                    }
+                }
+
+                //king.
+                pos = __builtin_ctzll(pieces[_nKing+(int)(side)]);
+                x = kingAttacks(pieces[_nKing+(int)(side)]) & ~attacked[(int)(!side)] & ~occupied[(int)(side)];
+                while (x)
+                {
+                    appendMove(_nKing+(int)(side), pos, popLSB(x), false);
+                    if (moveBuffer.size() > 0) {return false;}
+                }
+
+                return false;
+            }
+            else if (isInCheckDetailed(side) == 1)
+            {
+                //single check.
+                U32 pos = __builtin_ctzll(pieces[_nKing+(int)(side)]);
+                U64 x = kingAttacks(pieces[_nKing+(int)(side)]) & ~attacked[(int)(!side)] & ~occupied[(int)(side)];
+                while (x)
+                {
+                    appendMove(_nKing+(int)(side), pos, popLSB(x),true);
+                    if (moveBuffer.size() > 0) {return true;}
+                }
+
+                U64 p = (occupied[0] | occupied[1]);
+
+                //pawns.
+                U64 pawns = pieces[_nPawns+(int)(side)];
+                U64 pawnPosBoard;
+                while (pawns)
+                {
+                    pos = popLSB(pawns);
+                    pawnPosBoard = 1ull << pos;
+
+                    //en passant square included.
+                    x = pawnAttacks(pawnPosBoard,side) & ~occupied[(int)(side)];
+
+                    if (current.enPassantSquare != -1) {x &= (occupied[(int)(!side)] | (1ull << current.enPassantSquare));}
+                    else {x &= occupied[(int)(!side)];}
+
+                    //move forward.
+                    if (side==0)
+                    {
+                        x |= (pawnPosBoard << 8) & (~p);
+                        x |= ((((pawnPosBoard & FILE_2) << 8) & (~p)) << 8) & (~p);
+                    }
+                    else
+                    {
+                        x |= (pawnPosBoard >> 8 & (~p));
+                        x |= ((((pawnPosBoard & FILE_7) >> 8) & (~p)) >> 8) & (~p);
+                    }
+
+                    while (x)
+                    {
+                        appendMove(_nPawns+(int)(side), pos,popLSB(x), true);
+                        if (moveBuffer.size() > 0) {return true;}
+                    }
+                }
+
+                //bishops.
+                U64 bishops = pieces[_nBishops+(int)(side)];
+                while (bishops)
+                {
+                    pos = popLSB(bishops);
+                    x = magicBishopAttacks(p,pos) & ~occupied[(int)(side)];
+                    while (x)
+                    {
+                        appendMove(_nBishops+(int)(side), pos, popLSB(x), true);
+                        if (moveBuffer.size() > 0) {return true;}
+                    }
+                }
+
+                //knights.
+                U64 knights = pieces[_nKnights+(int)(side)];
+                while (knights)
+                {
+                    pos = popLSB(knights);
+                    x = knightAttacks(1ull << pos) & ~occupied[(int)(side)];
+                    while (x)
+                    {
+                        appendMove(_nKnights+(int)(side), pos, popLSB(x), true);
+                        if (moveBuffer.size() > 0) {return true;}
+                    }
+                }
+
+                //rook.
+                U64 rooks = pieces[_nRooks+(int)(side)];
+                while (rooks)
+                {
+                    pos = popLSB(rooks);
+                    x = magicRookAttacks(p,pos) & ~occupied[(int)(side)];
+                    while (x)
+                    {
+                        appendMove(_nRooks+(int)(side), pos, popLSB(x), true);
+                        if (moveBuffer.size() > 0) {return true;}
+                    }
+                }
+
+                //queen.
+                U64 queens = pieces[_nQueens+(int)(side)];
+                while (queens)
+                {
+                    pos = popLSB(queens);
+                    x = magicQueenAttacks(p,pos) & ~occupied[(int)(side)];
+                    while (x)
+                    {
+                        appendMove(_nQueens+(int)(side), pos, popLSB(x), true);
+                        if (moveBuffer.size() > 0) {return true;}
+                    }
+                }
+
+                return true;
+            }
+            else
+            {
+                //multiple check. only king moves allowed.
+                U32 pos = __builtin_ctzll(pieces[_nKing+(int)(side)]);
+                U64 x = kingAttacks(pieces[_nKing+(int)(side)]) & ~attacked[(int)(!side)] & ~occupied[(int)(side)];
+                while (x)
+                {
+                    appendMove(_nKing+(int)(side), pos, popLSB(x), true);
+                    if (moveBuffer.size() > 0) {return true;}
+                }
+
+                return true;
+            }
+        }
+
         void movePieces()
         {
             //remove piece from start square;
@@ -1345,7 +1591,7 @@ class Board {
             //see if checkmate or stalemate.
             bool turn = moveHistory.size() & 1;
 
-            bool inCheck = generatePseudoMoves(turn);
+            bool inCheck = generateEvalMoves(turn);
 
             if (moveBuffer.size() > 0)
             {

--- a/include/transposition.h
+++ b/include/transposition.h
@@ -61,6 +61,7 @@ const int ZHASH_ENPASSANT[8] = {773,774,775,776,777,778,779,780};
 
 void clearTT()
 {
+    rootCounter = 0;
     for (int i=0;i<(int)(hashTableMask + 1);i++)
     {
         hashTableAlways[i] = emptyStore;


### PR DESCRIPTION
Exit early if at least one legal move is found when checking for stalemate/checkmate. Increases nps by ~7%