### PR TITLE
feat(PIN-25): add internal iterative reduction

### DIFF
--- a/include/search.h
+++ b/include/search.h
@@ -164,6 +164,9 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
             //no hash table hit.
             b.updateOccupied();
             moveCache = b.orderMoves(ply);
+
+            //internal iterative reduction.
+            if (depth > 3) {depth--;}
         }
 
         //null move pruning.


### PR DESCRIPTION
Reduce depth by 1 whenever a hash miss occurs. Best results when depth > 3 before reduction.

### Results

Time control = 10+0.1 s
Hash size = 256 MB

```
   # PLAYER       :  RATING  ERROR  POINTS  PLAYED   (%)  CFS(%)    W    D    L  D(%)
   1 Pingu_new    :    18.3   14.3   855.5    1626    53      99  633  445  548    27
   2 Pingu        :     0.0   ----   770.5    1626    47     ---  548  445  633    27

White advantage = 6.27 +/- 7.44
Draw rate (equal opponents) = 27.43 % +/- 1.14
```