### PR TITLE
perf(PIN-42): optimise quiescence search move generation

### DIFF
--- a/include/search.h
+++ b/include/search.h
@@ -111,6 +111,7 @@ int alphaBetaQuiescence(Board &b, int alpha, int beta)
 
     int score;
     if (b.moveBuffer.size() == 0) {return inCheck ? b.evaluateBoard() : bestScore;}
+    //no need to update occupied, just did move-gen.
     std::vector<std::pair<U32,int> > moveCache = b.orderQMoves();
 
     for (const auto &[move,moveScore]: moveCache)

--- a/include/search.h
+++ b/include/search.h
@@ -110,7 +110,7 @@ int alphaBetaQuiescence(Board &b, int alpha, int beta)
     }
 
     int score;
-    if (b.moveBuffer.size() == 0) {return inCheck ? b.evaluateBoard() : bestScore;}
+    if (b.moveBuffer.size() == 0) {return inCheck ? -MATE_SCORE : bestScore;}
     //no need to update occupied, just did move-gen.
     std::vector<std::pair<U32,int> > moveCache = b.orderQMoves();
 

--- a/include/search.h
+++ b/include/search.h
@@ -95,10 +95,21 @@ int alphaBetaQuiescence(Board &b, int alpha, int beta)
             if (bestScore >= beta) {return bestScore;}
             alpha = bestScore;
         }
+
+        //generate regular tactical moves.
+        b.moveBuffer.clear();
+        b.generateCaptures(side, 0);
+    }
+    else
+    {
+        //generate check evasion.
+        U32 numChecks = b.isInCheckDetailed(side);
+        b.moveBuffer.clear();
+        b.generateCaptures(side, numChecks);
+        b.generateQuiets(side, numChecks);
     }
 
     int score;
-    b.generatePseudoQMoves(side);
     if (b.moveBuffer.size() == 0) {return inCheck ? b.evaluateBoard() : bestScore;}
     std::vector<std::pair<U32,int> > moveCache = b.orderQMoves();
 


### PR DESCRIPTION
Perform stand-pat pruning before move generation, and use the new move generation (captures and quiets) routine.

STC (10+0.1):
Total: 1000 W: 408 L: 332 D: 260
Elo gain: 26.9 ± 17.8

LTC (60+0.6):
Total: 602 W: 224 L: 152 D: 226
Elo gain: 42.4 ± 21.9