### PR TITLE
feat(PIN-24): improve root search

### DIFF
--- a/include/search.h
+++ b/include/search.h
@@ -548,12 +548,10 @@ int alphaBetaRoot(Board &b, int depth)
         if (itDepth > 1)
         {
             //put best move of previous iter to front.
-            std::pair<U32,int> temp = moveCache[0];
-            moveCache[0] = moveCache[pvIndex];
-            moveCache[pvIndex] = temp;
+            moveCache[pvIndex].second = INT_MAX;
 
             //sort rest of moves.
-            sort(moveCache.begin() + 1, moveCache.end(), [](const auto &a, const auto &b) {return a.second > b.second;});
+            sort(moveCache.begin(), moveCache.end(), [](const auto &a, const auto &b) {return a.second > b.second;});
         }
 
         //play moves.

--- a/include/search.h
+++ b/include/search.h
@@ -559,7 +559,17 @@ int alphaBetaRoot(Board &b, int depth)
         {
             U32 startMoveNodes = totalNodes;
             b.makeMove(moveCache[i].first);
-            score = -alphaBeta(b, -beta, -alpha, itDepth-1, 1, true);
+            if (itDepth >= 2 && i > 0)
+            {
+                //PV search.
+                score = -alphaBeta(b, -alpha-1, -alpha, itDepth-1, 1, true);
+                if (score > alpha)
+                {
+                    //full window re-search.
+                    score = -alphaBeta(b, -beta, -alpha, itDepth-1, 1, true);
+                }
+            }
+            else {score = -alphaBeta(b, -beta, -alpha, itDepth-1, 1, true);}
             b.unmakeMove();
             if (score > alpha) {alpha = score; pvIndex = i;}
             moveCache[i].second = totalNodes - startMoveNodes;

--- a/include/search.h
+++ b/include/search.h
@@ -571,7 +571,13 @@ int alphaBetaRoot(Board &b, int depth)
             }
             else {score = -alphaBeta(b, -beta, -alpha, itDepth-1, 1, true);}
             b.unmakeMove();
-            if (score > alpha) {alpha = score; pvIndex = i;}
+            if (score > alpha)
+            {
+                alpha = score;
+                pvIndex = i;
+                storedBestMove = moveCache[i].first;
+                storedBestScore = score;
+            }
             moveCache[i].second = totalNodes - startMoveNodes;
         }
 
@@ -582,10 +588,6 @@ int alphaBetaRoot(Board &b, int depth)
         
         double iterationTime = std::chrono::duration<double, std::milli>(iterationFinishTime - iterationStartTime).count();
         double realTimeLeft = std::max(timeLeft - std::chrono::duration<double, std::milli>(std::chrono::high_resolution_clock::now()-startTime).count(), 0.);
-
-        //store best move and score.
-        storedBestMove = moveCache[pvIndex].first;
-        storedBestScore = alpha;
 
         //display info.
         std::cout << "info" <<

--- a/include/search.h
+++ b/include/search.h
@@ -571,7 +571,7 @@ int alphaBetaRoot(Board &b, int depth)
             }
             else {score = -alphaBeta(b, -beta, -alpha, itDepth-1, 1, true);}
             b.unmakeMove();
-            if (score > alpha)
+            if (score > alpha && !isSearchAborted)
             {
                 alpha = score;
                 pvIndex = i;

--- a/include/search.h
+++ b/include/search.h
@@ -571,13 +571,7 @@ int alphaBetaRoot(Board &b, int depth)
             }
             else {score = -alphaBeta(b, -beta, -alpha, itDepth-1, 1, true);}
             b.unmakeMove();
-            if (score > alpha)
-            {
-                alpha = score;
-                pvIndex = i;
-                storedBestMove = moveCache[i].first;
-                storedBestScore = score;
-            }
+            if (score > alpha) {alpha = score; pvIndex = i;}
             moveCache[i].second = totalNodes - startMoveNodes;
         }
 
@@ -588,6 +582,10 @@ int alphaBetaRoot(Board &b, int depth)
         
         double iterationTime = std::chrono::duration<double, std::milli>(iterationFinishTime - iterationStartTime).count();
         double realTimeLeft = std::max(timeLeft - std::chrono::duration<double, std::milli>(std::chrono::high_resolution_clock::now()-startTime).count(), 0.);
+
+        //store best move and score.
+        storedBestMove = moveCache[pvIndex].first;
+        storedBestScore = alpha;
 
         //display info.
         std::cout << "info" <<

--- a/include/uci.h
+++ b/include/uci.h
@@ -17,8 +17,8 @@ std::atomic_bool isSearching(false);
 
 void searchThread(Board &b, int depth, double moveTime)
 {
-    isSearchAborted = false; totalNodes = 0; timeLeft = moveTime;
-    int res = alphaBetaRoot(b, -MATE_SCORE, MATE_SCORE, depth);
+    isSearchAborted = false; timeLeft = moveTime;
+    int res = alphaBetaRoot(b, depth);
 
     //output best move after search is complete.
     std::cout << "info nodes " << totalNodes << " score cp " << res << std::endl;


### PR DESCRIPTION
- Changed the ordering of root moves. We still search previous iteration's PV, but subsequent moves are ordered by the number of nodes searched.
- Add PV search to root.
- Update best move for a fully searched move, even if not all moves searched at that depth iteration (biggest elo gain).

STC(10+0.1):
Total: 1000 W: 364 L: 299 D: 337
Elo gain: 22.9 ± 17.0