### PR TITLE
feat(PIN-26): adaptive null move pruning

### DIFF
--- a/include/search.h
+++ b/include/search.h
@@ -169,7 +169,8 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
     }
 
     //null move pruning.
-    if (nullMoveAllowed && !inCheck && depth >= nullMoveDepthLimit && b.phase > 0)
+    if (nullMoveAllowed && !inCheck && depth >= nullMoveDepthLimit &&
+        (b.occupied[side] ^ b.pieces[b._nKing+side] ^ b.pieces[b._nPawns+side]))
     {
         b.makeNullMove();
         int nullScore = -alphaBeta(b, -beta, -beta+1, depth-1-nullMoveR, ply+1, false);

--- a/include/search.h
+++ b/include/search.h
@@ -173,7 +173,7 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
         (b.occupied[side] ^ b.pieces[b._nKing+side] ^ b.pieces[b._nPawns+side]))
     {
         b.makeNullMove();
-        int nullScore = -alphaBeta(b, -beta, -beta+1, depth-1-nullMoveR, ply+1, false);
+        int nullScore = -alphaBeta(b, -beta, -beta+1, depth-1-nullMoveR-depth/6, ply+1, false);
         b.unmakeNullMove();
 
         //fail hard only for null move pruning.


### PR DESCRIPTION
Change null move reduction to R = 2 + depth/6

Another minor change - only perform null move if _side to move_ has minor pieces

STC (10+0.1):
Total: 1000 W: 373 L: 286 D: 341
Elo gain: 30.6 ± 16.9

LTC (60+0.6):
Total: 1000 W: 342 L: 233 D: 425
Elo gain: 38.6 ± 15.9