### PR TITLE
feat(PIN-29): improve time management

### DIFF
--- a/include/search.h
+++ b/include/search.h
@@ -522,7 +522,10 @@ int alphaBetaRoot(Board &b, int depth)
     bool inCheck = b.generatePseudoMoves(side);
 
     //checkmate or stalemate.
-    if (b.moveBuffer.size() == 0) {return inCheck ? -MATE_SCORE : 0;}
+    if (b.moveBuffer.size() == 0) {storedBestMove = 0; return inCheck ? -MATE_SCORE : 0;}
+
+    //if only one move, return immediately.
+    if (b.moveBuffer.size() == 1) {storedBestMove = b.moveBuffer[0]; return 0;}
 
     //order moves using old history.
     std::vector<std::pair<U32,int> > moveCache = b.orderMoves(0);


### PR DESCRIPTION
If only one legal move, then do not bother searching, return immediately.

Change time allocation to 5% time + 50% increment (previously it was 3% time + 75% increment).

STC (10+0.1):
Total: 1000 W: 351 L: 281 D: 368
Elo gain: 24.6 ± 18.2

STC (10+0.1) gauntlet, similar elo gains of ~10-20
