### PR TITLE
feat(PIN-30): add aspiration windows

### DIFF
--- a/include/search.h
+++ b/include/search.h
@@ -563,17 +563,37 @@ int alphaBetaRoot(Board &b, int depth)
         {
             U32 startMoveNodes = totalNodes;
             b.makeMove(moveCache[i].first);
-            if (itDepth >= 2 && i > 0)
+            if (i == 0)
             {
-                //PV search.
-                score = -alphaBeta(b, -alpha-1, -alpha, itDepth-1, 1, true);
-                if (score > alpha)
+                if (itDepth >= 5)
                 {
-                    //full window re-search.
+                    //aspiration window for pv move.
+                    alpha = std::max(storedBestScore - 200, alpha);
+                    beta = std::min(storedBestScore + 200, beta);
                     score = -alphaBeta(b, -beta, -alpha, itDepth-1, 1, true);
+                    if ((score <= alpha || score >= beta) && score != MATE_SCORE)
+                    {
+                        //shift to full search window.
+                        alpha = -MATE_SCORE-1; beta = MATE_SCORE;
+                        score = -alphaBeta(b, -beta, -alpha, itDepth-1, 1, true);
+                    }
                 }
+                else {score = -alphaBeta(b, -beta, -alpha, itDepth-1, 1, true);}
             }
-            else {score = -alphaBeta(b, -beta, -alpha, itDepth-1, 1, true);}
+            else
+            {
+                if (itDepth >= 2)
+                {
+                    //PV search.
+                    score = -alphaBeta(b, -alpha-1, -alpha, itDepth-1, 1, true);
+                    if (score > alpha)
+                    {
+                        //full window re-search.
+                        score = -alphaBeta(b, -beta, -alpha, itDepth-1, 1, true);
+                    }
+                }
+                else {score = -alphaBeta(b, -beta, -alpha, itDepth-1, 1, true);}
+            }
             b.unmakeMove();
             if (score > alpha && !isSearchAborted)
             {


### PR DESCRIPTION
Add simple aspiration window of (score ± 200) to the first move in root search for depth >= 5. This is then immediately widened to full window if search fails low/high.

STC (10+0.1):
Total: 1000 W: 334 L: 293 D: 373
Elo gain: 14.4 ± 16.6

LTC (60+0.6):
Total: 1000 W: 336 L: 243 D: 421
Elo gain: 32.8 ± 15.8