### PR TITLE
feat(PIN-51): adjust lmr formula

### DIFF
--- a/include/search.h
+++ b/include/search.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <atomic>
 #include <algorithm>
+#include <cmath>
 
 #include "bitboard.h"
 #include "transposition.h"
@@ -413,9 +414,10 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
         if (depth >= 2 && numMoves > 0)
         {
             //late move reductions (non pv nodes).
-            if (depth >= 3 && (alpha == (beta - 1)) && numMoves >= 3 && !inCheck)
+            int LMR = std::floor(0.5 * std::log((double)depth) * std::log((double)(numMoves+1)));
+            if (LMR && (alpha == (beta - 1)) && !inCheck)
             {
-                score = -alphaBeta(b, -beta, -alpha, depth-2, ply+1, true);
+                score = -alphaBeta(b, -beta, -alpha, depth-1-LMR, ply+1, true);
             }
             else {score = alpha + 1;}
 

--- a/include/search.h
+++ b/include/search.h
@@ -414,7 +414,7 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
         if (depth >= 2 && numMoves > 0)
         {
             //late move reductions (non pv nodes).
-            int LMR = std::floor(0.5 * std::log((double)depth) * std::log((double)(numMoves+1)));
+            int LMR = int(0.5 * std::log((double)depth) * std::log((double)(numMoves+1)));
             if (LMR && (alpha == (beta - 1)) && !inCheck)
             {
                 score = -alphaBeta(b, -beta, -alpha, depth-1-LMR, ply+1, true);


### PR DESCRIPTION
Change lmr from constant (classical) reduction to a reduction which varies with depth and movecount.

R = floor(0.5 * log(d) * log(c))

where d is depth, c is that move's order (1, 2, 3, ...) and log is natural logarithm

STC (10+0.1):
Total: 1000 W: 370 L: 272 D: 358
Elo gain: 34.6 ± 16.8

LTC (60+0.6):
Total: 1000 W: 356 L: 204 D: 440
Elo gain: 54.3 ± 15.7