### PR TITLE
fix(PIN-66): do not save aborted search in hash table

### DIFF
--- a/include/search.h
+++ b/include/search.h
@@ -212,7 +212,7 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
             }
 
             //update transposition table.
-            if (bestScore != MATE_SCORE) {ttSave(bHash, depth, hashMove, bestScore, false, true);}
+            if (!isSearchAborted && bestScore != MATE_SCORE) {ttSave(bHash, depth, hashMove, bestScore, false, true);}
             return bestScore;
         }
         if (bestScore > alpha) {alpha = bestScore; isExact = true;}
@@ -263,7 +263,7 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
             {
                 //beta cutoff.
                 //update transposition table.
-                if (score != MATE_SCORE) {ttSave(bHash, depth, move, score, false, true);}
+                if (!isSearchAborted && score != MATE_SCORE) {ttSave(bHash, depth, move, score, false, true);}
                 return score;
             }
             if (score > alpha) {alpha = score; isExact = true;}
@@ -353,7 +353,7 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
                 }
 
                 //update transposition table.
-                if (score != MATE_SCORE) {ttSave(bHash, depth, move, score, false, true);}
+                if (!isSearchAborted && score != MATE_SCORE) {ttSave(bHash, depth, move, score, false, true);}
                 return score;
             }
             if (score > alpha) {alpha = score; isExact = true;}
@@ -390,7 +390,7 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
             {
                 //beta cutoff.
                 //update transposition table.
-                if (score != MATE_SCORE) {ttSave(bHash, depth, move, score, false, true);}
+                if (!isSearchAborted && score != MATE_SCORE) {ttSave(bHash, depth, move, score, false, true);}
                 return score;
             }
             if (score > alpha) {alpha = score; isExact = true;}
@@ -490,7 +490,7 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
                 }
 
                 //update transposition table.
-                if (score != MATE_SCORE) {ttSave(bHash, depth, move, score, false, true);}
+                if (!isSearchAborted && score != MATE_SCORE) {ttSave(bHash, depth, move, score, false, true);}
                 return score;
             }
             if (score > alpha) {alpha = score; isExact = true;}
@@ -503,7 +503,7 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
     if (numMoves == 0) {return inCheck ? -MATE_SCORE : 0;}
 
     //update transposition table.
-    if (bestScore != -MATE_SCORE) {ttSave(bHash, depth, bestMove, bestScore, isExact, false);}
+    if (!isSearchAborted && bestScore != -MATE_SCORE) {ttSave(bHash, depth, bestMove, bestScore, isExact, false);}
     return bestScore;
 }
 


### PR DESCRIPTION
If the search is aborted, all nodes in progress will immediately return 0 (draw score). We do not want these scores to be saved in the hash table as a clear blunder will be marked as drawish and this can be disastrous for the next search.