### PR TITLE
feat(PIN-48): disable null move based on tt

### DIFF
--- a/include/search.h
+++ b/include/search.h
@@ -172,6 +172,8 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
         else {if (tableEntry.evaluation <= alpha) {return tableEntry.evaluation;}}
     }
 
+    if (hashHit && tableEntry.depth >= depth-nullMoveR-depth/6 && !tableEntry.isBeta && tableEntry.evaluation < beta) {nullMoveAllowed = false;}
+
     //null move pruning.
     if (nullMoveAllowed && !inCheck && depth >= nullMoveDepthLimit &&
         (b.occupied[side] ^ b.pieces[b._nKing+side] ^ b.pieces[b._nPawns+side]))


### PR DESCRIPTION
If a tt entry exists where the score (searched to sufficient depth) was below beta, we disable null move as it is unlikely to lead to a cutoff.

STC (10+0.1):
Total: 1000 W: 343 L: 302 D: 355
Elo gain: 14.5 ± 16.7