### PR TITLE
feat(PIN-12): add futility pruning

### DIFF
--- a/include/search.h
+++ b/include/search.h
@@ -418,7 +418,7 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
     bool canFutilityPrune = depth <= futilityDepthLimit &&
                             alpha == (beta - 1) &&
                             !inCheck &&
-                            b.regularEval() + futilityMargins[depth-1] < alpha;
+                            b.regularEval() + futilityMargins[depth-1] <= alpha;
 
     for (int i=0;i<(int)(moveCache.size());i++)
     {


### PR DESCRIPTION
Add futility pruning for depth <= 2 of the main search.

Pruning conditions:
- Not in check
- Move does not give check
- Non-PV node
- |alpha| != mate, |beta| != mate
- Prune quiet moves only

STC (10+0.1):
Total: 1000 W: 371 L: 256 D: 373
Elo gain: 40.8 ± 16.6

LTC (60+0.6):
Total: 1000 W: 344 L: 213 D: 443
Elo gain: 46.3 ± 15.6