### PR TITLE
fix(PIN-80): futility pruning conditions

### DIFF
--- a/include/search.h
+++ b/include/search.h
@@ -428,23 +428,19 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
     bool canFutilityPrune = depth <= futilityDepthLimit &&
                             alpha == (beta - 1) &&
                             !inCheck &&
+                            abs(alpha) <= MATE_BOUND && abs(beta) <= MATE_BOUND &&
                             b.regularEval() + futilityMargins[depth-1] <= alpha;
 
     for (int i=0;i<(int)(moveCache.size());i++)
     {
         move = moveCache[i].first;
 
-        //futility pruning.
-        if (canFutilityPrune && numMoves > 0 &&
-            abs(alpha) != MATE_SCORE && abs(beta) != MATE_SCORE &&
-            !b.isCheckingMove(move))
-        {
-            continue;
-        }
-
         if (hashHit && (move == hashMove)) {continue;}
         if ((move == killers[0]) || (move == killers[1])) {continue;}
-        
+
+        //futility pruning.
+        if (canFutilityPrune && numMoves > 0 && !b.isCheckingMove(move)) {continue;}
+
         b.makeMove(move);
         if (depth >= 2 && numMoves > 0)
         {


### PR DESCRIPTION
Change conditions so that futility pruning is not applied when alpha or beta are near mate values. Also move conditional statement for alpha/beta out of loop since it will never change.

STC (10+0.1):
Total: 1000 W: 321 L: 288 D: 391
Elo gain: 11.6 ± 16.2
