### PR TITLE
feat(PIN-90): add reverse futility pruning

### DIFF
--- a/testing/engine.py
+++ b/testing/engine.py
@@ -7,7 +7,7 @@ import os
 from subprocess import Popen, PIPE
 
 ENGINE_EXE = "Pingu.exe"
-REL_PATH = "\\..\\build\\"
+REL_PATH = "\\..\\"
 
 class Engine:
 


### PR DESCRIPTION
Add simple reverse futility pruning whose margin is proportional to depth.

We have a depth limit of 8, this can be tuned later.

```
Elo   | 70.93 +- 19.58 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 874 W: 390 L: 214 D: 270
Penta | [22, 65, 149, 117, 84]

Elo   | 54.86 +- 16.85 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1060 W: 419 L: 253 D: 388
Penta | [26, 82, 189, 166, 67]
```