### PR TITLE
fix(PIN-91): constant seed in TT

### DIFF
--- a/include/transposition.h
+++ b/include/transposition.h
@@ -155,13 +155,7 @@ inline bool ttProbe(U64 zHash, int ply)
 
 void populateRandomNums()
 {
-    std::random_device _rd;
-    std::size_t seed;
-
-    if (_rd.entropy()) {seed = _rd();}
-    else {seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();}
-
-    std::mt19937 _mt(seed);
+    std::mt19937_64 _mt(974u);
     std::uniform_int_distribution<unsigned long long> _dist(0ull,ULLONG_MAX);
 
     for (int i=0;i<781;i++) {randomNums[i] = _dist(_mt);}

--- a/include/transposition.h
+++ b/include/transposition.h
@@ -155,8 +155,9 @@ inline bool ttProbe(U64 zHash, int ply)
 
 void populateRandomNums()
 {
-    std::mt19937_64 _mt(974u);
-    std::uniform_int_distribution<unsigned long long> _dist(0ull,ULLONG_MAX);
+    std::seed_seq ss{866052240, 524600418, 294500052, 845566473};
+    std::mt19937_64 _mt(ss);
+    std::uniform_int_distribution<unsigned long long> _dist(1ull,ULLONG_MAX);
 
     for (int i=0;i<781;i++) {randomNums[i] = _dist(_mt);}
 }


### PR DESCRIPTION
Fix mersenne twister to use 64-bit version.

Set a constant randomly-generated seed sequence so engine searches the same every time.

Overall no change to elo.

```
Elo   | 0.95 +- 11.12 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | -0.14 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2562 W: 880 L: 873 D: 809
Penta | [122, 281, 480, 264, 134]

Elo   | 1.42 +- 12.85 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | -0.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1710 W: 525 L: 518 D: 667
Penta | [56, 219, 303, 216, 61]
```