### PR TITLE
refactor(PIN-92): simplify killer and history updates

### DIFF
--- a/include/board.h
+++ b/include/board.h
@@ -1919,6 +1919,15 @@ class Board {
                 for (int j=0;j<64;j++) {history[i][j] = 0;}
             }
         }
+
+        void updateKiller(U32 killer, int ply)
+        {
+            if (killerMoves[ply][0] != killer)
+            {
+                killerMoves[ply][1] = killerMoves[ply][0];
+                killerMoves[ply][0] = killer;
+            }
+        }
 };
 
 #endif // BOARD_H_INCLUDED

--- a/include/board.h
+++ b/include/board.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <algorithm>
 #include <iostream>
+#include <unordered_set>
 
 #include "constants.h"
 #include "bitboard.h"
@@ -1927,6 +1928,66 @@ class Board {
                 killerMoves[ply][1] = killerMoves[ply][0];
                 killerMoves[ply][0] = killer;
             }
+        }
+
+        void updateHistory(const std::unordered_set<U32> &singles, U32 cutMove, int depth)
+        {
+            bool shouldAge = false;
+
+            int delta = depth * depth;
+
+            //decrement history for single moves.
+            for (const auto &move: singles)
+            {
+                U32 pieceType = (move & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
+                U32 finishSquare = (move & MOVEINFO_FINISHSQUARE_MASK) >> MOVEINFO_FINISHSQUARE_OFFSET;
+                history[pieceType][finishSquare] -= delta;
+                if (history[pieceType][finishSquare] < -HISTORY_MAX) {shouldAge = true;}
+            }
+
+            //increment history for cut move.
+            U32 pieceType = (cutMove & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
+            U32 finishSquare = (cutMove & MOVEINFO_FINISHSQUARE_MASK) >> MOVEINFO_FINISHSQUARE_OFFSET;
+            history[pieceType][finishSquare] += delta;
+            if (history[pieceType][finishSquare] > HISTORY_MAX) {shouldAge = true;}
+
+            //age history if necessary.
+            if (shouldAge) {ageHistory();}
+        }
+
+        void updateHistory(const std::unordered_set<U32> &singles, const std::vector<std::pair<U32,int> > &quiets, int index, U32 cutMove, int depth)
+        {
+            bool shouldAge = false;
+
+            int delta = depth * depth;
+
+            //decrement history for single moves.
+            for (const auto &move: singles)
+            {
+                U32 pieceType = (move & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
+                U32 finishSquare = (move & MOVEINFO_FINISHSQUARE_MASK) >> MOVEINFO_FINISHSQUARE_OFFSET;
+                history[pieceType][finishSquare] -= delta;
+                if (history[pieceType][finishSquare] < -HISTORY_MAX) {shouldAge = true;}
+            }
+
+            //decrement history for quiets.
+            for (int i=0;i<index;i++)
+            {
+                if (singles.contains(quiets[i].first)) {continue;}
+                U32 pieceType = (quiets[i].first & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
+                U32 finishSquare = (quiets[i].first & MOVEINFO_FINISHSQUARE_MASK) >> MOVEINFO_FINISHSQUARE_OFFSET;
+                history[pieceType][finishSquare] -= delta;
+                if (history[pieceType][finishSquare] < -HISTORY_MAX) {shouldAge = true;}
+            }
+
+            //increment history for cut move.
+            U32 pieceType = (cutMove & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
+            U32 finishSquare = (cutMove & MOVEINFO_FINISHSQUARE_MASK) >> MOVEINFO_FINISHSQUARE_OFFSET;
+            history[pieceType][finishSquare] += delta;
+            if (history[pieceType][finishSquare] > HISTORY_MAX) {shouldAge = true;}
+
+            //age history if necessary.
+            if (shouldAge) {ageHistory();}
         }
 };
 

--- a/include/search.h
+++ b/include/search.h
@@ -242,7 +242,9 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
         if (bestScore >= beta)
         {
             //beta cutoff.
-            if (b.currentMove.capturedPieceType == 15)
+            bool isQuiet = (hashMove & MOVEINFO_CAPTUREDPIECETYPE_MASK) >> MOVEINFO_CAPTUREDPIECETYPE_OFFSET == 15 &&
+            (hashMove & MOVEINFO_FINISHPIECETYPE_MASK) >> MOVEINFO_FINISHPIECETYPE_OFFSET == (hashMove & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
+            if (isQuiet)
             {
                 b.updateKiller(hashMove, ply);
                 if (depth >= 5) {b.updateHistory(singleQuiets, hashMove, depth);}
@@ -254,10 +256,9 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
         }
         if (bestScore > alpha) {alpha = bestScore; isExact = true;}
         bestMove = hashMove;
-        if ((hashMove & MOVEINFO_CAPTUREDPIECETYPE_MASK) >> MOVEINFO_CAPTUREDPIECETYPE_OFFSET == 15)
-        {
-            singleQuiets.insert(hashMove);
-        }
+        bool isQuiet = (hashMove & MOVEINFO_CAPTUREDPIECETYPE_MASK) >> MOVEINFO_CAPTUREDPIECETYPE_OFFSET == 15 &&
+        (hashMove & MOVEINFO_FINISHPIECETYPE_MASK) >> MOVEINFO_FINISHPIECETYPE_OFFSET == (hashMove & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
+        if (isQuiet) {singleQuiets.insert(hashMove);}
     }
 
     //internal iterative reduction on hash miss.

--- a/include/search.h
+++ b/include/search.h
@@ -241,12 +241,7 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
             //beta cutoff.
             if (b.currentMove.capturedPieceType == 15)
             {
-                //update killers.
-                if (b.killerMoves[ply][0] != hashMove)
-                {
-                    b.killerMoves[ply][1] = b.killerMoves[ply][0];
-                    b.killerMoves[ply][0] = hashMove;
-                }
+                b.updateKiller(hashMove, ply);
 
                 //increase history score.
                 if (depth >= 5)
@@ -360,12 +355,7 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
             if (score >= beta)
             {
                 //beta cutoff.
-                //update killers.
-                if (b.killerMoves[ply][0] != move)
-                {
-                    b.killerMoves[ply][1] = b.killerMoves[ply][0];
-                    b.killerMoves[ply][0] = move;
-                }
+                b.updateKiller(move, ply);
 
                 //update history.
                 if (depth >= 5)
@@ -500,12 +490,7 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
             if (score >= beta)
             {
                 //beta cutoff.
-                //update killers.
-                if (b.killerMoves[ply][0] != move)
-                {
-                    b.killerMoves[ply][1] = b.killerMoves[ply][0];
-                    b.killerMoves[ply][0] = move;
-                }
+                b.updateKiller(move, ply);
 
                 //update history.
                 if (depth >= 5)

--- a/include/search.h
+++ b/include/search.h
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <algorithm>
 #include <cmath>
+#include <unordered_set>
 
 #include "bitboard.h"
 #include "transposition.h"
@@ -228,6 +229,8 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
     int bestScore = -MATE_SCORE; U32 bestMove = 0;
     int numMoves = 0;
 
+    std::unordered_set<U32> singleQuiets;
+
     //try hash move.
     if (hashHit && b.isValidMove(hashMove, inCheck))
     {
@@ -242,13 +245,7 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
             if (b.currentMove.capturedPieceType == 15)
             {
                 b.updateKiller(hashMove, ply);
-
-                //increase history score.
-                if (depth >= 5)
-                {
-                    b.history[b.currentMove.pieceType][b.currentMove.finishSquare] += depth * depth;
-                    if (b.history[b.currentMove.pieceType][b.currentMove.finishSquare] > HISTORY_MAX) {b.ageHistory();}
-                }
+                if (depth >= 5) {b.updateHistory(singleQuiets, hashMove, depth);}
             }
 
             //update transposition table.
@@ -257,6 +254,10 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
         }
         if (bestScore > alpha) {alpha = bestScore; isExact = true;}
         bestMove = hashMove;
+        if ((hashMove & MOVEINFO_CAPTUREDPIECETYPE_MASK) >> MOVEINFO_CAPTUREDPIECETYPE_OFFSET == 15)
+        {
+            singleQuiets.insert(hashMove);
+        }
     }
 
     //internal iterative reduction on hash miss.
@@ -313,17 +314,13 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
     }
 
     //try killers.
-    U32 killers[2] = {0,0};
     for (int i=0;i<2;i++)
     {
         move = b.killerMoves[ply][i];
-        //check that killer is not hash move.
-        if (hashHit && move == hashMove) {continue;}
-        //check that killers not identical.
-        if (i == 1 && move == b.killerMoves[ply][0]) {continue;}
+        //check if move was played before.
+        if (singleQuiets.contains(move)) {continue;}
         //check if killer is valid.
         if (!b.isValidMove(move, inCheck)) {continue;}
-        killers[i] = move;
 
         b.makeMove(move);
         if (depth >= 2 && numMoves > 0)
@@ -356,36 +353,7 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
             {
                 //beta cutoff.
                 b.updateKiller(move, ply);
-
-                //update history.
-                if (depth >= 5)
-                {
-                    bool shouldAge = false;
-
-                    b.history[b.currentMove.pieceType][b.currentMove.finishSquare] += depth * depth;
-                    if (b.history[b.currentMove.pieceType][b.currentMove.finishSquare] > HISTORY_MAX) {shouldAge = true;}
-
-                    //decrement hash move.
-                    if (hashHit &&
-                        (((hashMove & MOVEINFO_CAPTUREDPIECETYPE_MASK) >> MOVEINFO_CAPTUREDPIECETYPE_OFFSET) == 15))
-                    {
-                        U32 pieceType = (hashMove & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
-                        U32 finishSquare = (hashMove & MOVEINFO_FINISHSQUARE_MASK) >> MOVEINFO_FINISHSQUARE_OFFSET;
-                        b.history[pieceType][finishSquare] -= depth * depth;
-                        if (b.history[pieceType][finishSquare] < -HISTORY_MAX) {shouldAge = true;}
-                    }
-
-                    //decrement previous killer.
-                    if (i > 0 && killers[0] != 0 && killers[0] != hashMove)
-                    {
-                        U32 pieceType = (killers[0] & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
-                        U32 finishSquare = (killers[0] & MOVEINFO_FINISHSQUARE_MASK) >> MOVEINFO_FINISHSQUARE_OFFSET;
-                        b.history[pieceType][finishSquare] -= depth * depth;
-                        if (b.history[pieceType][finishSquare] < -HISTORY_MAX) {shouldAge = true;}
-                    }
-
-                    if (shouldAge) {b.ageHistory();}
-                }
+                if (depth >= 5) {b.updateHistory(singleQuiets, move, depth);}
 
                 //update transposition table.
                 if (!isSearchAborted) {ttSave(bHash, ply, depth, move, score, false, true);}
@@ -395,6 +363,7 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
             bestScore = score;
             bestMove = move;
         }
+        singleQuiets.insert(move);
     }
 
     //bad captures.
@@ -453,8 +422,7 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
 
         move = moveCache[i].first;
 
-        if (hashHit && (move == hashMove)) {continue;}
-        if ((move == killers[0]) || (move == killers[1])) {continue;}
+        if (singleQuiets.contains(move)) {continue;}
 
         //futility pruning.
         if (canFutilityPrune && numMoves > 0 && !b.isCheckingMove(move)) {continue;}
@@ -491,47 +459,7 @@ int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nullMoveAl
             {
                 //beta cutoff.
                 b.updateKiller(move, ply);
-
-                //update history.
-                if (depth >= 5)
-                {
-                    bool shouldAge = false;
-
-                    b.history[b.currentMove.pieceType][b.currentMove.finishSquare] += depth * depth;
-                    if (b.history[b.currentMove.pieceType][b.currentMove.finishSquare] > HISTORY_MAX) {shouldAge = true;}
-
-                    //decrement hash move.
-                    if (hashHit &&
-                        (((hashMove & MOVEINFO_CAPTUREDPIECETYPE_MASK) >> MOVEINFO_CAPTUREDPIECETYPE_OFFSET) == 15))
-                    {
-                        U32 pieceType = (hashMove & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
-                        U32 finishSquare = (hashMove & MOVEINFO_FINISHSQUARE_MASK) >> MOVEINFO_FINISHSQUARE_OFFSET;
-                        b.history[pieceType][finishSquare] -= depth * depth;
-                        if (b.history[pieceType][finishSquare] < -HISTORY_MAX) {shouldAge = true;}
-                    }
-
-                    //decrement previous killers.
-                    for (int j=0;j<2;j++)
-                    {
-                        if (killers[j] == 0 || killers[j] == hashMove) {continue;}
-                        U32 pieceType = (killers[j] & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
-                        U32 finishSquare = (killers[j] & MOVEINFO_FINISHSQUARE_MASK) >> MOVEINFO_FINISHSQUARE_OFFSET;
-                        b.history[pieceType][finishSquare] -= depth * depth;
-                        if (b.history[pieceType][finishSquare] < -HISTORY_MAX) {shouldAge = true;}
-                    }
-
-                    //decrement previous quiets.
-                    for (int j=0;j<i;j++)
-                    {
-                        if (moveCache[j].first == hashMove || moveCache[j].first == killers[0] || moveCache[j].first == killers[1]) {continue;}
-                        U32 pieceType = (moveCache[j].first & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
-                        U32 finishSquare = (moveCache[j].first & MOVEINFO_FINISHSQUARE_MASK) >> MOVEINFO_FINISHSQUARE_OFFSET;
-                        b.history[pieceType][finishSquare] -= depth * depth;
-                        if (b.history[pieceType][finishSquare] < -HISTORY_MAX) {shouldAge = true;}
-                    }
-
-                    if (shouldAge) {b.ageHistory();}
-                }
+                if (depth >= 5) {b.updateHistory(singleQuiets, moveCache, i, move, depth);}
 
                 //update transposition table.
                 if (!isSearchAborted) {ttSave(bHash, ply, depth, move, score, false, true);}


### PR DESCRIPTION
Simplify the updates to killer and history tables when a beta-cut occurs.

Also fix a small bug where hash moves which are non-capture promotions are allowed into killer table.