### PR TITLE
feat(PIN-94): age history instead of clearing it

### DIFF
--- a/include/search.h
+++ b/include/search.h
@@ -512,6 +512,9 @@ int alphaBetaRoot(Board &b, int depth, bool gensfen = false)
         moveCache.push_back(std::pair<U32,int>(move, 0));
     }
 
+    //age history at root.
+    b.ageHistory(8);
+
     //reset best score and best move.
     storedBestScore = -MATE_SCORE; storedBestMove = 0;
     int pvIndex = 0;

--- a/include/search.h
+++ b/include/search.h
@@ -512,9 +512,6 @@ int alphaBetaRoot(Board &b, int depth, bool gensfen = false)
         moveCache.push_back(std::pair<U32,int>(move, 0));
     }
 
-    //reset history at root.
-    b.clearHistory();
-
     //reset best score and best move.
     storedBestScore = -MATE_SCORE; storedBestMove = 0;
     int pvIndex = 0;

--- a/include/uci.h
+++ b/include/uci.h
@@ -254,6 +254,9 @@ void prepareForNewGame(Board &b)
     //reset hash table.
     clearTT();
     rootCounter = 0;
+
+    //clear history.
+    b.clearHistory();
 }
 
 void gensfenCommand(Board &b, const std::vector<std::string> &words)


### PR DESCRIPTION
```
Elo   | 9.67 +- 6.70 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7044 W: 2500 L: 2304 D: 2240
Penta | [279, 726, 1410, 734, 373]

Elo   | 10.01 +- 11.84 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 0.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2048 W: 663 L: 604 D: 781
Penta | [59, 229, 412, 242, 82]
```