### PR TITLE
feat(PIN-10): mvv-lva for winning captures

### DIFF
--- a/include/search.h
+++ b/include/search.h
@@ -139,7 +139,7 @@ int alphaBetaQuiescence(Board &b, int ply, int alpha, int beta)
         b.generateQuiets(side, numChecks);
     }
 
-    std::vector<std::pair<U32,int> > moveCache = b.orderQMoves(inCheck ? -INT_MAX : 0);
+    std::vector<std::pair<U32,int> > moveCache = inCheck ? b.orderQMovesInCheck() : b.orderQMoves();
 
     for (const auto &[move,moveScore]: moveCache)
     {


### PR DESCRIPTION
Use SEE to identify winning/losing captures.

Winning/equal captures are sorted by MVV/LVA, and losing captures are sorted by SEE.

```
Elo   | 11.92 +- 7.49 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5540 W: 1951 L: 1761 D: 1828
Penta | [237, 557, 1042, 647, 287]

Elo   | 9.50 +- 6.53 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6546 W: 2061 L: 1882 D: 2603
Penta | [190, 724, 1312, 811, 236]
```