### PR TITLE
feat(PIN-22): use pst scores in quiet move ordering

### DIFF
--- a/include/board.h
+++ b/include/board.h
@@ -1864,12 +1864,19 @@ class Board {
 
             for (const auto &move: moveBuffer)
             {
-                scoredMoves.push_back(
-                    std::pair<U32,int>(
-                        move,
-                        history[(move & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET][(move & MOVEINFO_FINISHSQUARE_MASK) >> MOVEINFO_FINISHSQUARE_OFFSET]
-                    )
-                );
+                U32 pieceType = (move & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
+                U32 startSquare = (move & MOVEINFO_STARTSQUARE_MASK) >> MOVEINFO_STARTSQUARE_OFFSET;
+                U32 finishSquare = (move & MOVEINFO_FINISHSQUARE_MASK) >> MOVEINFO_FINISHSQUARE_OFFSET;
+                int moveScore = history[pieceType][finishSquare];
+                if (pieceType & 1)
+                {
+                    moveScore += PIECE_TABLES_START[pieceType >> 1][finishSquare] - PIECE_TABLES_START[pieceType >> 1][startSquare];
+                }
+                else
+                {
+                    moveScore += PIECE_TABLES_START[pieceType >> 1][finishSquare ^ 56] - PIECE_TABLES_START[pieceType >> 1][startSquare ^ 56];
+                }
+                scoredMoves.push_back(std::pair<U32,int>(move, moveScore));
             }
 
             //sort the moves.


### PR DESCRIPTION
When ordering quiet moves, use the sum of history scores and pst scores.

LTC incomplete but probably not a regression.

```
Elo   | 6.85 +- 4.38 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 3.00]
Games | N: 15518 W: 5148 L: 4842 D: 5528
Penta | [605, 1702, 2928, 1830, 694]

Elo   | 5.71 +- 11.16 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 0.37 (-2.94, 2.94) [0.00, 3.00]
Games | N: 2192 W: 664 L: 628 D: 900
Penta | [63, 251, 441, 269, 72]
```