### PR TITLE
refactor(PIN-63): optimise repetition detection

### DIFF
--- a/include/board.h
+++ b/include/board.h
@@ -56,6 +56,7 @@ class Board {
         std::vector<gameState> stateHistory;
         std::vector<U32> moveHistory;
         std::vector<U32> hashHistory;
+        std::vector<int> irrevMoveInd;
 
         std::vector<U32> captureBuffer;
         std::vector<U32> quietBuffer;
@@ -207,6 +208,7 @@ class Board {
             stateHistory.clear();
             moveHistory.clear();
             hashHistory.clear();
+            irrevMoveInd.clear();
 
             std::vector<std::string> temp; temp.push_back("");
 
@@ -1614,6 +1616,13 @@ class Board {
             zHashPieces ^= randomNums[ZHASH_TURN];
             zHashState = 0;
 
+            //irrev move.
+            if (currentMove.pieceType >> 1 == _nPawns >> 1 || currentMove.capturedPieceType != 15 ||
+                (currentMove.pieceType >> 1 == _nKing >> 1 && abs((int)currentMove.finishSquare - (int)currentMove.startSquare) == 2))
+            {
+                irrevMoveInd.push_back(moveHistory.size() - 1);
+            }
+
             //if double-pawn push, set en-passant square.
             //otherwise, set en-passant square to -1.
             if (currentMove.pieceType >> 1 == _nPawns >> 1 && abs((int)(currentMove.finishSquare)-(int)(currentMove.startSquare)) == 16)
@@ -1687,6 +1696,11 @@ class Board {
             stateHistory.pop_back();
             moveHistory.pop_back();
             hashHistory.pop_back();
+
+            if (irrevMoveInd.size() && irrevMoveInd.back() >= (int)moveHistory.size())
+            {
+                irrevMoveInd.pop_back();
+            }
         }
 
         void makeNullMove()
@@ -1697,6 +1711,8 @@ class Board {
 
             zHashPieces ^= randomNums[ZHASH_TURN];
             zHashState = 0;
+
+            irrevMoveInd.push_back(moveHistory.size() - 1);
 
             current.enPassantSquare = -1;
 
@@ -1712,6 +1728,8 @@ class Board {
 
             zHashPieces ^= randomNums[ZHASH_TURN];
             zHashState = 0;
+
+            irrevMoveInd.pop_back();
 
             if (current.enPassantSquare != -1)
             {

--- a/include/search.h
+++ b/include/search.h
@@ -79,18 +79,13 @@ void collectPVRoot(Board &b, U32 bestMove, int depth)
 inline bool isDraw(Board &b)
 {
     //check if current position has appeared in moveHistory.
-    bool draw = false;
     U32 zHash = b.zHashPieces ^ b.zHashState;
-    for (int i=(int)(b.moveHistory.size())-1;i>=0;i--)
+    int finishInd = b.irrevMoveInd.size() ? b.irrevMoveInd.back() : -1;
+    for (int i=(int)(b.hashHistory.size())-4;i>finishInd;i-=2)
     {
-        if ((((b.moveHistory[i] & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET) >> 1) == (b._nPawns >> 1) ||
-            ((b.moveHistory[i] & MOVEINFO_CAPTUREDPIECETYPE_MASK) >> MOVEINFO_CAPTUREDPIECETYPE_OFFSET) != 15)
-        {
-            break;
-        }
-        else if (b.hashHistory[i] == zHash) {draw = true; break;}
+        if (b.hashHistory[i] == zHash) {return true;}
     }
-    return draw;
+    return false;
 }
 
 inline bool checkTime()

--- a/include/uci.h
+++ b/include/uci.h
@@ -250,6 +250,7 @@ void prepareForNewGame(Board &b)
     b.stateHistory.clear();
     b.moveHistory.clear();
     b.hashHistory.clear();
+    b.irrevMoveInd.clear();
 
     //reset hash table.
     clearTT();


### PR DESCRIPTION
Keep track of the last irreversible move (capture/pawn/null). When detecting repetitions, only check positions which are even ply distance (must be same side to move).

```
Elo   | 4.51 +- 4.42 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 15414 W: 5117 L: 4917 D: 5380
Penta | [554, 1653, 3167, 1705, 628]
```