### PR TITLE
feat(PIN-78): add game result to gensfen

### DIFF
--- a/include/gensfen.h
+++ b/include/gensfen.h
@@ -1,0 +1,13 @@
+#ifndef GENSFEN_H_INCLUDED
+#define GENSFEN_H_INCLUDED
+
+#include <string>
+
+struct gensfenData
+{
+    std::string fen;
+    int eval;
+    double result;
+};
+
+#endif // GENSFEN_H_INCLUDED

--- a/testing/engine.py
+++ b/testing/engine.py
@@ -1,5 +1,5 @@
 """
-Expects to find 'Pingu.exe' in /build folder
+Expects to find 'Pingu.exe' in parent folder.
 
 """
 

--- a/tuning/generate_data.py
+++ b/tuning/generate_data.py
@@ -21,7 +21,7 @@ ARGS = (HASH, DEPTH, POSITIONS, RANDOMPLY, MAXPLY, EVALBOUND)
 
 def gensfen_worker(hash, depth, positions, randomply, maxply, evalbound):
     import engine
-    e = engine.Engine("Pingu.exe", "\\..\\..\\build\\")
+    e = engine.Engine("Pingu.exe", "\\..\\..\\")
     e.stdin("setoption name Hash value " + str(hash))
     time.sleep(0.5)
 


### PR DESCRIPTION
Add game result (1 for white win, 0 for black win, 0.5 for draw) to gensfen data.

If the game exceeds the ply limit, we assign the result based on arbitrary score boundaries (-400 < score < 400 is draw).