### PR TITLE
feat(PIN-109): reduce bad captures

### DIFF
--- a/include/search.h
+++ b/include/search.h
@@ -372,12 +372,25 @@ inline int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nul
         b.makeMove(move);
         if (depth >= 2 && numMoves > 0)
         {
-            //PV search.
-            score = -alphaBeta(b, -alpha-1, -alpha, depth-1, ply+1, true);
-            if (score > alpha && score < beta)
+            if (depth >= 3 && (alpha == (beta - 1)) && numMoves >= 3 && !inCheck)
             {
-                //full window re-search.
-                score = -alphaBeta(b, -beta, -alpha, depth-1, ply+1, true);
+                score = -alphaBetaQuiescence(b, ply+1, -beta, -alpha);
+                if (score < alpha)
+                {
+                    score = -alphaBeta(b, -beta, -alpha, depth-2, ply+1, true);
+                }
+            }
+            else {score = alpha + 1;}
+
+            //PV search.
+            if (score > alpha)
+            {
+                score = -alphaBeta(b, -alpha-1, -alpha, depth-1, ply+1, true);
+                if (score > alpha && score < beta)
+                {
+                    //full window re-search.
+                    score = -alphaBeta(b, -beta, -alpha, depth-1, ply+1, true);
+                }
             }
         }
         else {score = -alphaBeta(b, -beta, -alpha, depth-1, ply+1, true);}


### PR DESCRIPTION
Late move reductions are used on bad captures (SEE < 0) provided that a preliminary qSearch fails low.

```
Elo   | 10.05 +- 5.16 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 10232 W: 3602 L: 3306 D: 3324
Penta | [437, 1025, 1978, 1157, 519]
```