### PR TITLE
fix(PIN-112,PIN-113): fix reduction conditions for bad captures and stop engine crashing

### DIFF
--- a/include/board.h
+++ b/include/board.h
@@ -42,7 +42,7 @@ class Board {
         std::vector<int> irrevMoveInd;
 
         std::vector<U32> moveBuffer;
-        std::vector<std::pair<U32, int> > qMoveCache[32] = {};
+        std::vector<std::pair<U32, int> > qMoveCache[64] = {};
         std::vector<std::pair<U32, int> > moveCache[MAXDEPTH+1] = {};
 
         gameState current = {

--- a/include/search.h
+++ b/include/search.h
@@ -375,7 +375,7 @@ inline int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nul
             if (depth >= 3 && (alpha == (beta - 1)) && numMoves >= 3 && !inCheck)
             {
                 score = -alphaBetaQuiescence(b, ply+1, -beta, -alpha);
-                if (score < alpha)
+                if (score <= alpha)
                 {
                     score = -alphaBeta(b, -beta, -alpha, depth-2, ply+1, true);
                 }

--- a/include/search.h
+++ b/include/search.h
@@ -246,13 +246,13 @@ inline int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nul
                 if (canLateMoveReduce && depth >= 3 && movesPlayed >= 3) {reduction = 1;}
                 break;
             case BAD_CAPTURES:
-                // if (canLateMoveReduce && depth >= 3 && movesPlayed >= 3)
-                // {
-                //     b.makeMove(move);
-                //     score = -alphaBetaQuiescence(b, ply+1, -beta, -alpha);
-                //     b.unmakeMove();
-                //     if (score <= alpha) {reduction = 1;}
-                // }
+                if (canLateMoveReduce && depth >= 3 && movesPlayed >= 3)
+                {
+                    b.makeMove(move);
+                    score = -alphaBetaQuiescence(b, ply+1, 0, -beta, -alpha);
+                    b.unmakeMove();
+                    if (score <= alpha) {reduction = 1;}
+                }
                 break;
             case QUIET_MOVES:
                 if (canLateMoveReduce && movesPlayed > 0) {reduction = int(0.5 * std::log((double)depth) * std::log((double)(movesPlayed+1)));}
@@ -264,11 +264,6 @@ inline int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nul
         if (depth >= 2 && movesPlayed > 0)
         {
             if (reduction > 0) {score = -alphaBeta(b, -beta, -alpha, depth-1-reduction, ply+1, true);}
-            else if (movePicker.stage == BAD_CAPTURES && canLateMoveReduce && depth >= 3 && movesPlayed >= 3)
-            {
-                score = -alphaBetaQuiescence(b, ply+1, 0, -beta, -alpha);
-                if (score < alpha) {score = -alphaBeta(b, -beta, -alpha, depth-2, ply+1, true);}
-            }
             else {score = alpha + 1;}
 
             if (score > alpha)

--- a/include/search.h
+++ b/include/search.h
@@ -246,13 +246,6 @@ inline int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nul
                 if (canLateMoveReduce && depth >= 3 && movesPlayed >= 3) {reduction = 1;}
                 break;
             case BAD_CAPTURES:
-                if (canLateMoveReduce && depth >= 3 && movesPlayed >= 3)
-                {
-                    b.makeMove(move);
-                    score = -alphaBetaQuiescence(b, ply+1, 0, -beta, -alpha);
-                    b.unmakeMove();
-                    if (score <= alpha) {reduction = 1;}
-                }
                 break;
             case QUIET_MOVES:
                 if (canLateMoveReduce && movesPlayed > 0) {reduction = int(0.5 * std::log((double)depth) * std::log((double)(movesPlayed+1)));}
@@ -264,6 +257,12 @@ inline int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nul
         if (depth >= 2 && movesPlayed > 0)
         {
             if (reduction > 0) {score = -alphaBeta(b, -beta, -alpha, depth-1-reduction, ply+1, true);}
+            else if (movePicker.stage == BAD_CAPTURES && canLateMoveReduce && depth >= 3 && movesPlayed >= 3)
+            {
+                score = -alphaBetaQuiescence(b, ply+1, 0, -beta, -alpha);
+                if (score <= alpha) {score = -alphaBeta(b, -beta, -alpha, depth-2, ply+1, true);}
+                else {score = alpha + 1;}
+            }
             else {score = alpha + 1;}
 
             if (score > alpha)


### PR DESCRIPTION
Change the reduction conditions for bad captures for score <= alpha rather than score < alpha.

Increase maximum ply of qsearch move cache to stop crashing.

```
Elo   | 6.13 +- 4.25 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, -3.00]
Games | N: 14788 W: 5111 L: 4850 D: 4827
Penta | [643, 1494, 2921, 1631, 705]
```