### PR TITLE
feat(PIN-111): adjust late move pruning

### DIFF
--- a/include/search.h
+++ b/include/search.h
@@ -27,7 +27,7 @@ static const int futilityDepthLimit = 2;
 const std::array<int, futilityDepthLimit> futilityMargins = {150, 400};
 
 static const int lateMovePruningDepthLimit = 4;
-const std::array<int, lateMovePruningDepthLimit> lateMovePruningMargins = {8, 14, 20, 26};
+const std::array<int, lateMovePruningDepthLimit> lateMovePruningMargins = {6, 10, 14, 18};
 
 const std::array<int, 3> aspirationDelta = {50, 200, 2 * MATE_SCORE};
 const std::array<int, 4> betaDelta = {1, 50, 200, 2 * MATE_SCORE};


### PR DESCRIPTION
Use a more aggressive scheme for late move pruning at low depths.

```
Elo   | 8.56 +- 4.73 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 12466 W: 4380 L: 4073 D: 4013
Penta | [555, 1288, 2332, 1411, 647]

Elo   | 9.36 +- 4.78 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 10174 W: 3287 L: 3013 D: 3874
Penta | [309, 1113, 2031, 1263, 371]
```