### PR TITLE
feat(PIN-114): lazy SEE evaluation

### DIFF
--- a/include/board.h
+++ b/include/board.h
@@ -42,10 +42,8 @@ class Board {
         std::vector<int> irrevMoveInd;
 
         std::vector<U32> moveBuffer;
-        std::vector<std::pair<U32, int> > qMoveCache[64] = {};
-        std::vector<std::pair<U32, int> > qBadCaptures[64] = {};
-        std::vector<std::pair<U32, int> > moveCache[MAXDEPTH+1] = {};
-        std::vector<std::pair<U32, int> > badCaptures[MAXDEPTH+1] = {};
+        std::vector<std::pair<U32, int> > moveCache[MAXDEPTH+1+64] = {};
+        std::vector<std::pair<U32, int> > badCaptures[MAXDEPTH+1+64] = {};
 
         gameState current = {
             .canKingCastle = {true,true},
@@ -1020,51 +1018,6 @@ class Board {
 
             //sort the moves.
             std::sort(moveCache[ply].begin(), moveCache[ply].end(), [](auto &a, auto &b) {return a.second > b.second;});
-        }
-
-        void orderQMoves(int qply)
-        {
-            qMoveCache[qply].clear();
-
-            for (const auto &move: moveBuffer)
-            {
-                U32 capturedPieceType = (move & MOVEINFO_CAPTUREDPIECETYPE_MASK) >> MOVEINFO_CAPTUREDPIECETYPE_OFFSET;
-                U32 pieceType = (move & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
-
-                if (pieceType >= capturedPieceType || pieceType < _nQueens || see.evaluate(move) >= 0)
-                {
-                    int score = 16 * (15 - capturedPieceType) + pieceType;
-                    qMoveCache[qply].push_back(std::pair<U32, int>(move, score));
-                }
-            }
-
-            //sort the moves.
-            std::sort(qMoveCache[qply].begin(), qMoveCache[qply].end(), [](auto &a, auto &b) {return a.second > b.second;});
-        }
-
-        void orderQMovesInCheck(int qply)
-        {
-            qMoveCache[qply].clear();
-
-            for (const auto &move: moveBuffer)
-            {
-                U32 pieceType = (move & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
-                U32 finishPieceType = (move & MOVEINFO_FINISHPIECETYPE_MASK) >> MOVEINFO_FINISHPIECETYPE_OFFSET;
-                U32 capturedPieceType = (move & MOVEINFO_CAPTUREDPIECETYPE_MASK) >> MOVEINFO_CAPTUREDPIECETYPE_OFFSET;
-                if (capturedPieceType != 15 || pieceType != finishPieceType)
-                {
-                    int score = see.evaluate(move);
-                    qMoveCache[qply].push_back(std::pair<U32, int>(move, score));
-                }
-                else
-                {
-                    //non-capture moves.
-                    qMoveCache[qply].push_back(std::pair<U32, int>(move, 0));
-                }
-            }
-
-            //sort the moves.
-            std::sort(qMoveCache[qply].begin(), qMoveCache[qply].end(), [](auto &a, auto &b) {return a.second > b.second;});
         }
 };
 

--- a/include/board.h
+++ b/include/board.h
@@ -43,7 +43,9 @@ class Board {
 
         std::vector<U32> moveBuffer;
         std::vector<std::pair<U32, int> > qMoveCache[64] = {};
+        std::vector<std::pair<U32, int> > qBadCaptures[64] = {};
         std::vector<std::pair<U32, int> > moveCache[MAXDEPTH+1] = {};
+        std::vector<std::pair<U32, int> > badCaptures[MAXDEPTH+1] = {};
 
         gameState current = {
             .canKingCastle = {true,true},
@@ -982,13 +984,10 @@ class Board {
             {
                 U32 capturedPieceType = (move & MOVEINFO_CAPTUREDPIECETYPE_MASK) >> MOVEINFO_CAPTUREDPIECETYPE_OFFSET;
                 U32 pieceType = (move & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
-                int score = 16 * (15 - capturedPieceType) + pieceType;
+                U32 finishPieceType = (move & MOVEINFO_FINISHPIECETYPE_MASK) >> MOVEINFO_FINISHPIECETYPE_OFFSET;
 
-                if (pieceType < capturedPieceType && pieceType >= _nQueens)
-                {
-                    int seeCheck = see.evaluate(move);
-                    if (seeCheck < 0) {score = seeCheck;}
-                }
+                int score = 32 * (15 - capturedPieceType) + pieceType;
+                score += finishPieceType != pieceType ? (15 - finishPieceType) : 0;
 
                 moveCache[ply].push_back(std::pair<U32, int>(move, score));
             }

--- a/include/movepicker.h
+++ b/include/movepicker.h
@@ -109,13 +109,7 @@ class MovePicker
                     U32 move = b->moveCache[ply][moveIndex++].first;
                     if (move == hashMove) {continue;}
 
-                    //check if we perform SEE.
-                    U32 pieceType = (move & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
-                    U32 capturedPieceType = (move & MOVEINFO_CAPTUREDPIECETYPE_MASK) >> MOVEINFO_CAPTUREDPIECETYPE_OFFSET;
-
-                    bool shouldCheck = (capturedPieceType == 15) || (pieceType >= _nQueens && seeValues[pieceType >> 1] > seeValues[capturedPieceType >> 1]);
-
-                    if (shouldCheck)
+                    if (shouldCheckSEE(move))
                     {
                         int seeScore = b->see.evaluate(move);
                         if (seeScore < 0)
@@ -216,14 +210,8 @@ class QMovePicker
                 while (moveIndex != b->moveCache[ply].size())
                 {
                     U32 move = b->moveCache[ply][moveIndex++].first;
-                    
-                    //check if we perform SEE.
-                    U32 pieceType = (move & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
-                    U32 capturedPieceType = (move & MOVEINFO_CAPTUREDPIECETYPE_MASK) >> MOVEINFO_CAPTUREDPIECETYPE_OFFSET;
 
-                    bool shouldCheck = (capturedPieceType == 15) || (pieceType >= _nQueens && seeValues[pieceType >> 1] > seeValues[capturedPieceType >> 1]);
-
-                    if (shouldCheck)
+                    if (shouldCheckSEE(move))
                     {
                         int seeScore = b->see.evaluate(move);
                         if (seeScore < 0)

--- a/include/search.h
+++ b/include/search.h
@@ -100,7 +100,7 @@ inline bool checkTime()
     else {return true;}
 }
 
-inline int alphaBetaQuiescence(Board &b, int ply, int qply, int alpha, int beta)
+inline int alphaBetaQuiescence(Board &b, int ply, int alpha, int beta)
 {
     //check time.
     totalNodes++;
@@ -125,13 +125,13 @@ inline int alphaBetaQuiescence(Board &b, int ply, int qply, int alpha, int beta)
     }
 
     U32 numChecks = inCheck ? util::isInCheckDetailed(b.side, b.pieces, b.occupied) : 0;
-    QMovePicker movePicker(&b, qply, numChecks);
+    QMovePicker movePicker(&b, ply, numChecks);
 
     //loop through moves and search them.
     while (U32 move = movePicker.getNext())
     {
         b.makeMove(move);
-        int score = -alphaBetaQuiescence(b, ply+1, qply+1, -beta, -alpha);
+        int score = -alphaBetaQuiescence(b, ply+1, -beta, -alpha);
         b.unmakeMove();
 
         if (score > bestScore)
@@ -178,7 +178,7 @@ inline int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nul
     }
 
     //qSearch at horizon.
-    if (depth <= 0) {totalNodes--; return alphaBetaQuiescence(b, ply, 0, alpha, beta);}
+    if (depth <= 0) {totalNodes--; return alphaBetaQuiescence(b, ply, alpha, beta);}
 
     //main search.
     bool inCheck = util::isInCheck(b.side, b.pieces, b.occupied);
@@ -217,7 +217,7 @@ inline int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nul
     int movesPlayed = 0; int quietsPlayed = 0;
     U32 numChecks = inCheck ? util::isInCheckDetailed(b.side, b.pieces, b.occupied) : 0;
 
-    MovePicker movePicker = MovePicker(&b, ply, numChecks, hashMove);
+    MovePicker movePicker(&b, ply, numChecks, hashMove);
 
     bool canLateMovePrune = canPrune && depth <= lateMovePruningDepthLimit;
 
@@ -251,7 +251,7 @@ inline int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nul
             case BAD_CAPTURES:
                 if (canLateMoveReduce && depth >= 3 && movesPlayed >= 3)
                 {
-                    score = -alphaBetaQuiescence(b, ply+1, 0, -beta, -alpha);
+                    score = -alphaBetaQuiescence(b, ply+1, -beta, -alpha);
                     if (score <= alpha) {reduction = 1;}
                 }
                 break;

--- a/include/see.h
+++ b/include/see.h
@@ -19,6 +19,14 @@ const std::array<int,6> seeValues =
     100,
 }};
 
+inline bool shouldCheckSEE(const U32 move)
+{
+    U32 pieceType = (move & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
+    U32 capturedPieceType = (move & MOVEINFO_CAPTUREDPIECETYPE_MASK) >> MOVEINFO_CAPTUREDPIECETYPE_OFFSET;
+
+    return (capturedPieceType == 15) || (pieceType >= _nQueens && seeValues[pieceType >> 1] > seeValues[capturedPieceType >> 1]);
+}
+
 class SEE
 {
     private:


### PR DESCRIPTION
Only perform static exchange evaluation just before playing a capture for greater efficient in fail-high nodes.

Change MVV/LVA slightly to prioritise promotions to higher-valued pieces.

Use same move-ordering functions for main search and q search.

```
Elo   | 9.69 +- 5.05 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 10796 W: 3789 L: 3488 D: 3519
Penta | [481, 1073, 2044, 1264, 536]
```