### PR TITLE
fix(PIN-120): quiet move detection in gensfen

### DIFF
--- a/include/uci.h
+++ b/include/uci.h
@@ -365,7 +365,10 @@ void gensfenCommand(Board &b, const std::vector<std::string> &words)
             }
 
             //update output buffer.
-            bool isQuiet = !util::isInCheck(b.side, b.pieces, b.occupied) && ((storedBestMove & MOVEINFO_CAPTUREDPIECETYPE_MASK) >> MOVEINFO_CAPTUREDPIECETYPE_OFFSET) == 15;
+            U32 pieceType = (storedBestMove & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
+            U32 capturedPieceType = (storedBestMove & MOVEINFO_CAPTUREDPIECETYPE_MASK) >> MOVEINFO_CAPTUREDPIECETYPE_OFFSET;
+            U32 finishPieceType = (storedBestMove & MOVEINFO_FINISHPIECETYPE_MASK) >> MOVEINFO_FINISHPIECETYPE_OFFSET;
+            bool isQuiet = !util::isInCheck(b.side, b.pieces, b.occupied) && capturedPieceType == 15 && pieceType == finishPieceType;
             if (isQuiet) {outputBuffer.push_back(gensfenData(positionToFen(b.pieces, b.current, b.side), score, 0.5));}
 
             b.makeMove(storedBestMove);

--- a/tuning/generate_data.py
+++ b/tuning/generate_data.py
@@ -9,7 +9,7 @@ import sys
 import time
 import multiprocessing
 
-HASH = 256
+HASH = 64
 
 DEPTH = 8
 POSITIONS = 10000


### PR DESCRIPTION
Don't append a position to gensfen data if the best move is a promotion.