### PR TITLE
fix(PIN-126): do not update killer/history on aborted search

### DIFF
--- a/include/search.h
+++ b/include/search.h
@@ -291,22 +291,25 @@ inline int alphaBeta(Board &b, int alpha, int beta, int depth, int ply, bool nul
         {
             if (score >= beta)
             {
-                bool isQuiet = movePicker.stage == QUIET_MOVES || movePicker.singleQuiets.contains(move);
-                if (isQuiet)
+                if (!isSearchAborted)
                 {
-                    //update killers.
-                    b.killer.update(move, ply);
-
-                    //update history.
-                    if (depth >= 5)
+                    bool isQuiet = movePicker.stage == QUIET_MOVES || movePicker.singleQuiets.contains(move);
+                    if (isQuiet)
                     {
-                        if (movePicker.stage == QUIET_MOVES) {b.history.update(movePicker.singleQuiets, b.moveCache[ply], movePicker.moveIndex - 1, move, depth);}
-                        else {b.history.update(movePicker.singleQuiets, move, depth);}
-                    }
-                }
+                        //update killers.
+                        b.killer.update(move, ply);
 
-                //update tt.
-                if (!isSearchAborted) {ttSave(bHash, ply, depth, move, score, false, true);}
+                        //update history.
+                        if (depth >= 5)
+                        {
+                            if (movePicker.stage == QUIET_MOVES) {b.history.update(movePicker.singleQuiets, b.moveCache[ply], movePicker.moveIndex - 1, move, depth);}
+                            else {b.history.update(movePicker.singleQuiets, move, depth);}
+                        }
+                    }
+
+                    //update tt.
+                    ttSave(bHash, ply, depth, move, score, false, true);
+                }
                 return score;
             }
             if (score > alpha) {alpha = score; isExact = true;}


### PR DESCRIPTION
```
Elo   | 0.93 +- 2.34 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 42402 W: 13745 L: 13632 D: 15025
Penta | [1506, 4549, 8966, 4686, 1494]
```