### PR TITLE
fix(PIN-116): static exchange eval xray check conditions

### DIFF
--- a/include/see.h
+++ b/include/see.h
@@ -90,12 +90,12 @@ class SEE
                 occ ^= attackingPieceBB;
 
                 //update possible x-ray attacks.
-                if (attackingPieceType == (_nRooks >> 1) || attackingPieceType == (_nQueens >> 1) || d == 1)
+                if (attackingPieceType == (_nRooks >> 1) || attackingPieceType == (_nQueens >> 1) || attackingPieceType == (_nKing >> 1))
                 {
                     //rook-like xray.
                     attackersBB |= magicRookAttacks(occ, finishSquare) & (pieces[_nRooks] | pieces[_nRooks+1] | pieces[_nQueens] | pieces[_nQueens+1]) & occ;
                 }
-                if (attackingPieceType == (_nPawns >> 1) || attackingPieceType == (_nBishops >> 1) || attackingPieceType == (_nQueens >> 1))
+                if (attackingPieceType == (_nPawns >> 1) || attackingPieceType == (_nBishops >> 1) || attackingPieceType == (_nQueens >> 1) || attackingPieceType == (_nKing >> 1))
                 {
                     //bishop-like xray.
                     attackersBB |= magicBishopAttacks(occ, finishSquare) & (pieces[_nBishops] | pieces[_nBishops+1] | pieces[_nQueens] | pieces[_nQueens+1]) & occ;

--- a/include/see.h
+++ b/include/see.h
@@ -36,6 +36,7 @@ class SEE
 
         U64 getLeastValuableAttacker(bool side, U64 attackersBB, U32 &attackingPieceType)
         {
+            if (!attackersBB) {return 0;}
             for (int i=_nPawns+(int)(side); i >= (int)_nKing+(int)(side); i-=2)
             {
                 U64 x = attackersBB & pieces[i];

--- a/include/see.h
+++ b/include/see.h
@@ -39,8 +39,7 @@ class SEE
             if (!attackersBB) {return 0;}
             for (int i=_nPawns+(int)(side); i >= (int)_nKing+(int)(side); i-=2)
             {
-                U64 x = attackersBB & pieces[i];
-                if (x)
+                if (U64 x = attackersBB & pieces[i])
                 {
                     attackingPieceType = i >> 1;
                     return x & (-x);


### PR DESCRIPTION
king captures/recaptures in SEE can reveal xray attacks. Fix the conditions under which we check for xrays.

```
Elo   | 3.58 +- 2.63 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 32480 W: 10532 L: 10197 D: 11751
Penta | [1040, 3474, 6935, 3693, 1098]
```