### PR TITLE
perf(PIN-146): cache lmr values in table

### DIFF
--- a/include/thread.h
+++ b/include/thread.h
@@ -24,6 +24,19 @@ const std::array<int, lateMovePruningDepthLimit> lateMovePruningMargins = {6, 10
 const std::array<int, 3> aspirationDelta = {50, 200, 2 * MATE_SCORE};
 const std::array<int, 4> betaDelta = {1, 50, 200, 2 * MATE_SCORE};
 
+std::array<std::array<int, 256>, MAXDEPTH> lmrTable = {};
+
+void populateLmrTable()
+{
+    for (int depth=1;depth<=MAXDEPTH;++depth)
+    {
+        for (int c=1;c<=256;++c)
+        {
+            lmrTable[depth-1][c-1] = int(0.5 * std::log((double)depth) * std::log((double)c));
+        }
+    }
+}
+
 inline int formatScore(int score)
 {
     return
@@ -270,7 +283,7 @@ class Thread
                         }
                         break;
                     case QUIET_MOVES:
-                        if (canLateMoveReduce && movesPlayed > 0) {reduction = int(0.5 * std::log((double)depth) * std::log((double)(movesPlayed+1)));}
+                        if (canLateMoveReduce && movesPlayed > 0) {reduction = lmrTable[depth-1][movesPlayed];}
                         break;
                 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -9,6 +9,7 @@ int main(int argc, const char** argv)
 {
     populateMagicTables();
     populateRandomNums();
+    populateLmrTable();
 
     if (argc == 1) {uciLoop();}
     else


### PR DESCRIPTION
Cache lmr values in an array to avoid recomputing them.

```
Elo   | 14.07 +- 5.96 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 6448 W: 2280 L: 2019 D: 2149
Penta | [201, 612, 1386, 775, 250]
```