### PR TITLE
perf(PIN-147): optimise nnue make/unmake with templates

### DIFF
--- a/include/nnue.h
+++ b/include/nnue.h
@@ -12,20 +12,18 @@
 #include "simd.h"
 #include "weights.h"
 
+template<int (*index)(U32 kingPos, U32 pieceType, U32 square), bool side>
 class alignas(32) Accumulator
 {
 public:
     alignas(32) short l1[32] = {};
     alignas(32) char cl1[32] = {};
     const U64 *pieces;
-    bool side;
     int kingPos = 0;
 
     Accumulator() {}
 
-    Accumulator(const U64 *_pieces, bool _side) : pieces(_pieces), side(_side) {}
-
-    virtual U32 index(U32 pieceType, U32 square) = 0;
+    Accumulator(const U64 *_pieces) : pieces(_pieces) {}
 
     template<void (Accumulator::*_zero)(U32, U32), void (Accumulator::*_one)(U32, U32)>
     void _move(U32 move)
@@ -98,7 +96,7 @@ public:
 
     void setOne(U32 pieceType, U32 square)
     {
-        U32 ind = index(pieceType, square);
+        U32 ind = index(kingPos, pieceType, square);
         __m256i w;
         __m256i l;
         for (size_t i = 0; i < 32; i += 16)
@@ -111,7 +109,7 @@ public:
 
     void setZero(U32 pieceType, U32 square)
     {
-        U32 ind = index(pieceType, square);
+        U32 ind = index(kingPos, pieceType, square);
         __m256i w;
         __m256i l;
         for (size_t i = 0; i < 32; i += 16)
@@ -134,31 +132,18 @@ public:
     }
 };
 
-class White : public Accumulator
+inline int whiteIndex(U32 kingPos, U32 pieceType, U32 square)
 {
-public:
-    White() : Accumulator() {}
+    return 704 * kingPos + 64 * (pieceType - 1) + square;
+}
 
-    White(const U64 *_pieces) : Accumulator(_pieces, 0) {}
-
-    U32 index(U32 pieceType, U32 square)
-    {
-        return 704 * kingPos + 64 * (pieceType - 1) + square;
-    }
-};
-
-class Black : public Accumulator
+inline int blackIndex(U32 kingPos, U32 pieceType, U32 square)
 {
-public:
-    Black() : Accumulator() {}
+    return 704 * (kingPos ^ 56) + 64 * (pieceType - 2 * (pieceType & 1)) + (square ^ 56);
+}
 
-    Black(const U64 *_pieces) : Accumulator(_pieces, 1) {}
-
-    U32 index(U32 pieceType, U32 square)
-    {
-        return 704 * (kingPos ^ 56) + 64 * (pieceType - 2 * (pieceType & 1)) + (square ^ 56);
-    }
-};
+typedef Accumulator<&whiteIndex, 0> White;
+typedef Accumulator<&blackIndex, 1> Black;
 
 class NNUE
 {

--- a/include/nnue.h
+++ b/include/nnue.h
@@ -27,17 +27,8 @@ public:
 
     virtual U32 index(U32 pieceType, U32 square) = 0;
 
-    void makeMove(U32 move)
-    {
-        _move(move, &Accumulator::setZero, &Accumulator::setOne);
-    }
-
-    void unmakeMove(U32 move)
-    {
-        _move(move, &Accumulator::setOne, &Accumulator::setZero);
-    }
-
-    void _move(U32 move, void (Accumulator::*_zero)(U32 x, U32 y), void (Accumulator::*_one)(U32 x, U32 y))
+    template<void (Accumulator::*_zero)(U32, U32), void (Accumulator::*_one)(U32, U32)>
+    void _move(U32 move)
     {
         U32 pieceType = (move & MOVEINFO_PIECETYPE_MASK) >> MOVEINFO_PIECETYPE_OFFSET;
         if (pieceType == side)
@@ -75,6 +66,16 @@ public:
         }
 
         cReLU();
+    }
+
+    void makeMove(U32 move)
+    {
+        _move<&Accumulator::setZero, &Accumulator::setOne>(move);
+    }
+
+    void unmakeMove(U32 move)
+    {
+        _move<&Accumulator::setOne, &Accumulator::setZero>(move);
     }
 
     void refresh()


### PR DESCRIPTION
Refactor out pure virtual + dynamic function pointers with templates to improve engine speed

```
Elo   | 31.99 +- 9.14 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 2712 W: 1019 L: 770 D: 923
Penta | [58, 237, 595, 330, 136]
```