### PR TITLE
feat(PIN-156): new nnue architecture

### DIFF
--- a/include/nnue.h
+++ b/include/nnue.h
@@ -79,7 +79,7 @@ public:
     void refresh()
     {
         kingPos = __builtin_ctzll(pieces[side]);
-        std::copy(b_0.begin(), b_0.end(), l1);
+        std::copy(perspective_b0.begin(), perspective_b0.end(), l1);
 
         setOne(!side, __builtin_ctzll(pieces[!side]));
         for (size_t i = 2; i < 12; ++i)
@@ -101,7 +101,7 @@ public:
         __m256i l;
         for (size_t i = 0; i < 32; i += 16)
         {
-            w = _mm256_loadu_si256((__m256i *)&w_0[ind][i]);
+            w = _mm256_loadu_si256((__m256i *)&perspective_w0[ind][i]);
             l = _mm256_loadu_si256((__m256i *)&l1[i]);
             _mm256_storeu_si256((__m256i *)&l1[i], _mm256_add_epi16(l, w));
         }
@@ -114,7 +114,7 @@ public:
         __m256i l;
         for (size_t i = 0; i < 32; i += 16)
         {
-            w = _mm256_loadu_si256((__m256i *)&w_0[ind][i]);
+            w = _mm256_loadu_si256((__m256i *)&perspective_w0[ind][i]);
             l = _mm256_loadu_si256((__m256i *)&l1[i]);
             _mm256_storeu_si256((__m256i *)&l1[i], _mm256_sub_epi16(l, w));
         }
@@ -203,19 +203,21 @@ public:
         __m256i sum = _ZERO;
         __m256i l, w;
 
+        int index = (pieceCount - 1) / 8;
+
         for (size_t i = 0; i < 32; i += 32)
         {
             l = _mm256_loadu_si256((__m256i *)&white.cl1[i]);
-            w = _mm256_loadu_si256((__m256i *)&w_1[0][32 * (*side) + i]);
+            w = _mm256_loadu_si256((__m256i *)&stacks_w0[index][32 * (*side) + i]);
             sum = _mm256_add_epi32(sum, madd_epi8(l, w));
         }
         for (size_t i = 0; i < 32; i += 32)
         {
             l = _mm256_loadu_si256((__m256i *)&black.cl1[i]);
-            w = _mm256_loadu_si256((__m256i *)&w_1[0][32 * (!(*side)) + i]);
+            w = _mm256_loadu_si256((__m256i *)&stacks_w0[index][32 * (!(*side)) + i]);
             sum = _mm256_add_epi32(sum, madd_epi8(l, w));
         }
-        return hsum_8x32(sum) + b_1[0];
+        return hsum_8x32(sum) + stacks_b0[index];
     }
 };
 

--- a/nnue/model/checkpoint.py
+++ b/nnue/model/checkpoint.py
@@ -69,8 +69,8 @@ def save_model(model, optimizer, t_loss, v_loss):
 
 
 def early_stop():
-    RECENT_LOOKBACK = 8
-    DISTANT_LOOKBACK = 32
+    RECENT_LOOKBACK = 4
+    DISTANT_LOOKBACK = 16
 
     model_files = get_files()
 
@@ -99,6 +99,9 @@ def load_best():
 
         model = network().to("cpu")
         model.load_state_dict(checkpoint["model_state_dict"])
+
+        print("Loaded", best_file)
+
         return model
 
     return None


### PR DESCRIPTION
Train and implement a new nnue architecture: 2 x (45056 -> 32) -> 1, where for the final layer (64 -> 1) we have 4 different sets of weights indexed by `(piece_count - 1) / 8`.

```
Elo   | 92.49 +- 16.34 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 1138 W: 563 L: 267 D: 308
Penta | [23, 58, 206, 164, 118]
```
