### PR TITLE
feat(PIN-159): prune bad captures with SEE

### DIFF
--- a/include/thread.h
+++ b/include/thread.h
@@ -268,6 +268,13 @@ class Thread
                 //futility pruning.
                 if (canFutilityPrune && movesPlayed > 0 && movePicker.stage == QUIET_MOVES && !b.isCheckingMove(move)) {continue;}
 
+                //SEE pruning.
+                if (movePicker.stage == BAD_CAPTURES && movesPlayed > 0 && b.badCaptures[ply][movePicker.moveIndex - 1].second + 100 * depth < 0)
+                {
+                    movePicker.moveIndex = b.badCaptures[ply].size();
+                    continue;
+                }
+
                 //search with PVS. Research if reductions do not fail low.
                 b.makeMove(move);
 


### PR DESCRIPTION
In main search, prune losing captures if SEE value is below a depth-dependent threshold.

```
Elo   | 11.05 +- 5.20 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 8240 W: 2861 L: 2599 D: 2780
Penta | [241, 820, 1804, 946, 309]
```